### PR TITLE
Refactoring

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,16 +2,8 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --foreground-rgb: 0, 0, 0;
-  --background-start-rgb: 214, 219, 220;
-  --background-end-rgb: 255, 255, 255;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --foreground-rgb: 255, 255, 255;
-    --background-start-rgb: 0, 0, 0;
-    --background-end-rgb: 0, 0, 0;
-  }
+html,
+body {
+  height: 100vh;
+  overflow: auto;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import { Noto_Sans_KR } from 'next/font/google';
 import Header from '@/components/Header';
+import Footer from '@/components/Footer';
 
 const notoKR = Noto_Sans_KR({ weight: ['100', '300', '400', '500', '700', '900'], subsets: ['latin'] });
 
@@ -11,17 +12,11 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className={notoKR.className}>
-        <div className="h-auto min-h-[100vh]">
-          <Header />
-          {children}
-        </div>
-        <footer className="h-10 py-2  translate-y-[-50%]">
-          <p className="text-center text-[3vw] sm:text-sm text-secondary">
-            Be a better version of myself than yesterday | © 2023 YJ
-          </p>
-        </footer>
+    <html lang="en" className={notoKR.className}>
+      <body className="flex flex-col max-w-screen-2xl mx-auto">
+        <Header />
+        <main className="grow">{children}</main>
+        <Footer />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,14 @@
 import Profile from '@/components/Profile';
-import { getFeaturedOrNot } from '@/service/posts';
 import FeaturedPosts from '@/components/FeaturedPosts';
 import PostsSlide from '@/components/PostsSlide';
 
-export default async function Home() {
-  const featuredPost = await getFeaturedOrNot(true);
-  const allPosts = await getFeaturedOrNot(false);
-
+export default function Home() {
   return (
-    <div className="max-w-[90%] lg:max-w-[85%] xl:max-w-[75%] m-zero-auto">
+    <>
       <Profile />
-      <FeaturedPosts posts={featuredPost} />
-      <PostsSlide posts={allPosts} />
-    </div>
+      {/* @ts-expect-error Server Component */}
+      <FeaturedPosts />
+      {/* <PostsSlide posts={allPosts} /> */}
+    </>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,7 +8,8 @@ export default function Home() {
       <Profile />
       {/* @ts-expect-error Server Component */}
       <FeaturedPosts />
-      {/* <PostsSlide posts={allPosts} /> */}
+      {/* @ts-expect-error Server Component */}
+      <PostsSlide />
     </>
   );
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -26,7 +26,7 @@ export default async function PostPage({ params: { slug } }: ParamsProps) {
       <main className="px-5 py-1">
         <p className="flex items-center justify-end text-sm text-secondary py-2">
           <FcCalendar />
-          <span className="px-1">{current.date}</span>
+          <time className="px-1">{current.date.toString()}</time>
         </p>
         <div className="py-3">
           <h1 className="text-3xl font-bold">{current.title}</h1>

--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -3,10 +3,7 @@ import PostList from '@/components/PostList';
 
 export default async function PostsPage() {
   const posts = await getPosts();
+  const categories = [...new Set(posts.map(post => post.category))];
 
-  return (
-    <div className="max-w-[90%] lg:max-w-[85%] xl:max-w-[80%] m-zero-auto">
-      <PostList posts={posts} />
-    </div>
-  );
+  return <PostList posts={posts} categories={categories} />;
 }

--- a/src/components/Categories.tsx
+++ b/src/components/Categories.tsx
@@ -1,0 +1,28 @@
+type Props = {
+  categories: string[];
+  selected: string;
+  onClick: (category: string) => void;
+};
+
+export default function Categories({ categories, selected, onClick }: Props) {
+  return (
+    <nav className="sm:w-[8%] sm:text-center sm:ml-10">
+      <h2 className="underline underline-offset-8 decoration-highlight decoration-2 py-3 text-xs sm:text-sm">
+        Category
+      </h2>
+      <ul className="flex sm:inline-block justify-between">
+        {categories.map(category => (
+          <li
+            key={category}
+            onClick={() => onClick(category)}
+            className={`${
+              category === selected ? 'text-highlight' : 'text-primary'
+            } cursor-pointer px-1 pb-2 sm:px-0 sm:py-0.5 text-xs sm:text-sm whitespace-nowrap`}
+          >
+            {category}
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/ContactButton.tsx
+++ b/src/components/ContactButton.tsx
@@ -1,9 +1,0 @@
-import Link from 'next/link';
-
-export default function ContactButton() {
-  return (
-    <Link href="/contact" className="text-xs bg-highlight rounded-lg py-1 px-3 hover:shadow-highlight transition-all">
-      Contact Me
-    </Link>
-  );
-}

--- a/src/components/FeaturedPosts.tsx
+++ b/src/components/FeaturedPosts.tsx
@@ -1,15 +1,13 @@
 import { PostProps } from '@/service/posts';
-import PostCard from '@/components/PostCard';
+import { getFeaturedOrNot } from '@/service/posts';
+import PostGrid from './PostGrid';
 
-export default function FeaturedPosts({ posts }: { posts: PostProps[] }) {
+export default async function FeaturedPosts() {
+  const posts = await getFeaturedOrNot(true);
   return (
-    <section>
+    <section className="px-5 md:px-20">
       <h1 className="text-lg font-semibold py-3">Featured Posts</h1>
-      <div className="flex flex-wrap justify-center sm:justify-start">
-        {posts.map((post, i) => (
-          <PostCard post={post} version="md" key={i} />
-        ))}
-      </div>
+      <PostGrid posts={posts} />
     </section>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+export default function Footer() {
+  return (
+    <footer>
+      <p className="text-center text-[3vw] sm:text-sm text-secondary py-2">
+        Be a better version of myself than yesterday | © 2023 YJ
+      </p>
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,7 +16,7 @@ export default function Header() {
   const pathname = usePathname();
 
   return (
-    <header className="flex p-2 sm:p-4 justify-between max-w-[90%] lg:max-w-[85%] xl:max-w-[75%] m-zero-auto">
+    <header className="flex p-4 justify-between">
       <h1 className="text-base sm:text-lg font-bold whitespace-nowrap">
         <Link href="/">
           yj Log <span className="text-highlight">+</span>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -4,28 +4,20 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { PostProps } from '@/service/posts';
 
-export default function PostCard({ post, version }: { post: PostProps; version: 'sm' | 'md' }) {
+export default function PostCard({ post }: { post: PostProps }) {
   const { title, description, date, category, path } = post;
 
   return (
     <Link
-      className={
-        version === 'md'
-          ? 'rounded-md w-full sm:w-[48%] lg:w-[32%] shadow-card overflow-clip cursor-pointer m-1 inline-block hover:shadow-card-pop hover:transition-all hover:duration-500 hover:scale-[1.005]'
-          : 'rounded-md w-[96%] cursor-pointer shadow-card overflow-clip inline-block'
-      }
+      className="rounded-md w-full shadow-card overflow-clip cursor-pointer m-1 inline-block hover:shadow-card-pop hover:transition-all hover:duration-500 hover:scale-[1.005]"
       href={`/posts/${path}`}
     >
       <Image src={`/img/posts/${path}.png`} alt={path} width={400} height={100} className="object-contain w-[100%]" />
       <section className="py-2 px-3 text-center">
         <p className="text-right text-[0.6em] sm:text-xs text-secondary font-light">{date}</p>
         <div className="flex flex-col items-center">
-          <h2 className="text-[0.8em] sm:text-sm font-medium py-1 text-ellipsis overflow-hidden whitespace-nowrap">
-            {title}
-          </h2>
-          <p className="text-[0.6em] sm:text-xs font-light text-ellipsis overflow-hidden whitespace-nowrap w-full">
-            {description}
-          </p>
+          <h2 className="text-[0.8em] sm:text-sm font-medium py-1 truncate">{title}</h2>
+          <p className="text-[0.6em] sm:text-xs font-light truncate w-full">{description}</p>
           <span className="text-[0.6em] sm:text-xs rounded-lg bg-point px-2 py-0.5 my-3">{category}</span>
         </div>
       </section>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -16,7 +16,7 @@ export default function PostCard({ post }: { post: PostProps }) {
       <section className="py-2 px-3 text-center">
         <p className="text-right text-[0.6em] sm:text-xs text-secondary font-light">{date}</p>
         <div className="flex flex-col items-center">
-          <h2 className="text-[0.8em] sm:text-sm font-medium py-1 truncate">{title}</h2>
+          <h2 className="text-[0.8em] sm:text-sm font-medium py-1 w-full truncate">{title}</h2>
           <p className="text-[0.6em] sm:text-xs font-light truncate w-full">{description}</p>
           <span className="text-[0.6em] sm:text-xs rounded-lg bg-point px-2 py-0.5 my-3">{category}</span>
         </div>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -13,11 +13,11 @@ export default function PostCard({ post }: { post: PostProps }) {
       href={`/posts/${path}`}
     >
       <Image src={`/img/posts/${path}.png`} alt={path} width={400} height={100} className="object-contain w-[100%]" />
-      <section className="py-2 px-3 text-center">
-        <p className="text-right text-[0.6em] sm:text-xs text-secondary font-light">{date}</p>
-        <div className="flex flex-col items-center">
-          <h2 className="text-[0.8em] sm:text-sm font-medium py-1 w-full truncate">{title}</h2>
-          <p className="text-[0.6em] sm:text-xs font-light truncate w-full">{description}</p>
+      <section className="py-2 px-3 flex flex-col items-center">
+        <time className="self-end text-[0.6em] sm:text-xs text-secondary font-light">{date.toString()}</time>
+        <div className="flex flex-col items-center w-full">
+          <h2 className="text-[0.8em] sm:text-sm font-medium py-1 w-full truncate text-center">{title}</h2>
+          <p className="text-[0.6em] sm:text-xs font-light w-full truncate text-center">{description}</p>
           <span className="text-[0.6em] sm:text-xs rounded-lg bg-point px-2 py-0.5 my-3">{category}</span>
         </div>
       </section>

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,21 +1,20 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 import { PostProps } from '@/service/posts';
 
 export default function PostCard({ post, version }: { post: PostProps; version: 'sm' | 'md' }) {
   const { title, description, date, category, path } = post;
-  const router = useRouter();
 
   return (
-    <article
+    <Link
       className={
         version === 'md'
           ? 'rounded-md w-full sm:w-[48%] lg:w-[32%] shadow-card overflow-clip cursor-pointer m-1 inline-block hover:shadow-card-pop hover:transition-all hover:duration-500 hover:scale-[1.005]'
-          : 'rounded-md w-[96%] cursor-pointer shadow-card overflow-clip'
+          : 'rounded-md w-[96%] cursor-pointer shadow-card overflow-clip inline-block'
       }
-      onClick={() => router.push(`/posts/${path}`)}
+      href={`/posts/${path}`}
     >
       <Image src={`/img/posts/${path}.png`} alt={path} width={400} height={100} className="object-contain w-[100%]" />
       <section className="py-2 px-3 text-center">
@@ -30,6 +29,6 @@ export default function PostCard({ post, version }: { post: PostProps; version: 
           <span className="text-[0.6em] sm:text-xs rounded-lg bg-point px-2 py-0.5 my-3">{category}</span>
         </div>
       </section>
-    </article>
+    </Link>
   );
 }

--- a/src/components/PostGrid.tsx
+++ b/src/components/PostGrid.tsx
@@ -1,0 +1,17 @@
+import PostCard from '@/components/PostCard';
+import { PostProps } from '@/service/posts';
+
+type Props = {
+  posts: PostProps[];
+};
+export default function PostGrid({ posts }: Props) {
+  return (
+    <ul className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {posts.map((post, i) => (
+        <li>
+          <PostCard post={post} key={i} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/PostList.tsx
+++ b/src/components/PostList.tsx
@@ -1,46 +1,24 @@
 'use client';
-import { useEffect, useState } from 'react';
-import { PostProps, Category } from '@/service/posts';
-import PostCard from './PostCard';
+import { useState } from 'react';
+import { PostProps } from '@/service/posts';
+import PostGrid from './PostGrid';
+import Categories from './Categories';
 
-export const categories: Category[] = ['all posts', 'my story', 'frontend', 'backend', 'javascript'];
+type Props = {
+  posts: PostProps[];
+  categories: string[];
+};
 
-export default function PostList({ posts }: { posts: PostProps[] }) {
-  const [category, setCategory] = useState('all posts');
-  const [postList, setPostList] = useState<PostProps[]>([]);
+const ALL_POSTS = 'All Posts';
 
-  useEffect(() => {
-    const filteredPosts = category === 'all posts' ? posts : posts.filter(post => post.category === category);
-    setPostList(filteredPosts);
-  }, [category]);
+export default function PostList({ posts, categories }: Props) {
+  const [selected, setSelected] = useState(ALL_POSTS);
+  const filtered = selected === ALL_POSTS ? posts : posts.filter(post => post.category === selected);
 
   return (
-    <div className="flex py-7 sm:py-10 flex-col-reverse sm:flex-row sm:justify-between">
-      <main className="w-full sm:w-[80%]">
-        {postList.map((post, i) => (
-          <PostCard post={post} version="md" key={`${post.category}_${i}`} />
-        ))}
-      </main>
-      <nav className="sm:w-[8%] sm:text-center">
-        <h2 className="underline underline-offset-8 decoration-highlight decoration-2 py-3 text-xs sm:text-sm">
-          Category
-        </h2>
-        <ul className="flex sm:inline-block justify-between">
-          {categories.map(cate => (
-            <li
-              key={cate}
-              onClick={() => {
-                setCategory(cate);
-              }}
-              className={`${
-                cate === category ? 'text-highlight' : 'text-primary'
-              } cursor-pointer px-1 pb-2 sm:px-0 sm:py-0.5 text-xs sm:text-sm whitespace-nowrap`}
-            >
-              {cate}
-            </li>
-          ))}
-        </ul>
-      </nav>
+    <div className="flex p-7 sm:p-10 flex-col-reverse sm:flex-row sm:justify-between">
+      <PostGrid posts={filtered} />
+      <Categories categories={[ALL_POSTS, ...categories]} selected={selected} onClick={setSelected} />
     </div>
   );
 }

--- a/src/components/PostsSlide.tsx
+++ b/src/components/PostsSlide.tsx
@@ -1,41 +1,18 @@
-'use client';
-
-import Carousel from 'react-multi-carousel';
-import 'react-multi-carousel/lib/styles.css';
+import { getFeaturedOrNot } from '@/service/posts';
+import SingleCarousel from './SingleCarousel';
 import PostCard from './PostCard';
-import { PostProps } from '@/service/posts';
 
-const responsive = {
-  desktop: {
-    breakpoint: { max: 3000, min: 1024 },
-    items: 3,
-  },
-  tablet: {
-    breakpoint: { max: 1024, min: 768 },
-    items: 2,
-  },
-  mobile: {
-    breakpoint: { max: 767, min: 0 },
-    items: 1,
-  },
-};
+export default async function PostsSlide() {
+  const posts = await getFeaturedOrNot(false);
 
-export default function PostsSlide({ posts }: { posts: PostProps[] }) {
   return (
-    <div className="mt-10 mb-20">
+    <div className="mt-10 mb-20 px-5 md:px-20">
       <h1 className="text-lg font-semibold py-3">More Posts</h1>
-      <Carousel
-        responsive={responsive}
-        infinite={true}
-        autoPlay={true}
-        pauseOnHover={true}
-        centerMode={true}
-        removeArrowOnDeviceType={['mobile']}
-      >
+      <SingleCarousel>
         {posts.map((post, i) => (
-          <PostCard post={post} version="sm" key={`more_posts_${i}`} />
+          <PostCard post={post} key={`more_posts_${i}`} />
         ))}
-      </Carousel>
+      </SingleCarousel>
     </div>
   );
 }

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image';
+import Link from 'next/link';
 import avatarImg from 'public/img/avatar.png';
-import ContactButton from './ContactButton';
 
 export default function Profile() {
   return (
@@ -8,10 +8,12 @@ export default function Profile() {
       <figure className="rounded-full overflow-hidden w-32">
         <Image src={avatarImg} alt="avatar" priority />
       </figure>
-      <h1 className="text-xl font-bold">Welcome, I'm yj!</h1>
-      <p>Frontend engineer</p>
+      <h2 className="text-xl font-bold">{"Welcome, I'm yj!"}</h2>
+      <h3>Frontend engineer</h3>
       <p className="text-sm font-light pb-2">Better than yesterday</p>
-      <ContactButton />
+      <Link href="/contact" className="text-xs bg-highlight rounded-lg py-1 px-3 hover:shadow-highlight transition-all">
+        Contact Me
+      </Link>
     </div>
   );
 }

--- a/src/components/SingleCarousel.tsx
+++ b/src/components/SingleCarousel.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import Carousel from 'react-multi-carousel';
+import 'react-multi-carousel/lib/styles.css';
+
+const responsive = {
+  superLargeDesktop: {
+    breakpoint: { max: 4000, min: 3000 },
+    items: 4,
+  },
+  desktop: {
+    breakpoint: { max: 3000, min: 1024 },
+    items: 3,
+  },
+  tablet: {
+    breakpoint: { max: 1024, min: 464 },
+    items: 2,
+  },
+  mobile: {
+    breakpoint: { max: 464, min: 0 },
+    items: 2,
+  },
+};
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function SingleCarousel({ children }: Props) {
+  return (
+    <Carousel
+      responsive={responsive}
+      infinite={true}
+      autoPlay={true}
+      pauseOnHover={true}
+      centerMode={true}
+      removeArrowOnDeviceType={['mobile']}
+      itemClass="m-2"
+    >
+      {children}
+    </Carousel>
+  );
+}

--- a/src/service/posts.ts
+++ b/src/service/posts.ts
@@ -1,13 +1,11 @@
 import path from 'path';
 import { promises as fs } from 'fs';
 
-export type Category = 'all posts' | 'my story' | 'javascript' | 'frontend' | 'backend';
-
 export type PostProps = {
   title: string;
   description: string;
-  date: string;
-  category: Category;
+  date: Date;
+  category: string;
   path: string;
   featured: boolean;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
### refactoring 사항

1. 전체 레이아웃 관련 수정
- body 전체에 flex, flex-col 스타일 적용 후 footer에 레이아웃 배치와 관련된 css 속성을 붙이지 않고, main 태그로 children을 감싼 뒤, flex-grow 속성을 줘서, 화면에 따라 커지게끔 해두었다. flex를 적용하면 내부 컨텐츠 크기에 따라서 width가 결정이 되는데, flex-grow 를 0 보다 큰 값으로 세팅하면 남은 여백을 채워준다.
- 다만, global.css에 html과 body의 height을 먼저 설정해줬다. height은 viewport 전체이지만, 컨텐츠가 넘어갈경우엔 스크롤 속성이 생기게끔 해준 것이다.

2. PostCard 컴포넌트
- 나는 좀 바보같이 useRouter를 사용해서 router.push 를 이용해 포스트 클릭 시에 페이지를 이동하게 만들었다. 따라서, 해당 컴포넌트를 ‘use client’ 즉, 클라이언트 컴포넌트화 했는데, 이럴 필요없이 `Link` 태그로 감싸서 했다면 클라이언트 컴포넌트화 할 필요가 없었다.
- `overflow: hidden; text-overflow: ellipsis; white-space: no-wrap`를 다 쓰는 게 아니라, `truncate` 라는 tailwind에서 제공해주는 class를 사용하자
- `<time> `요소는 대부분의 웹 브라우저에서 특별한 형태로 랜더링 되지는 않지만, 검색 엔진의 검색 결과 향상이나 알림 및 스케줄과 같은 사용자 기능을 위해 날짜와 시간 데이터를 기계가 읽을 수 있는(machine-readable) 형태로 변환해주는 datetime 속성을 포함할 수 있다고 한다. 따라서, 앞으로 시간과 관련된 요소는 일반적인 span이 아닌 time을 써봐야겠다.

3. Home 페이지 구조 변경
처음에는 Home 페이지 상에서 featured posts와 non-featured posts를 전부 가져와 각 FeaturedPosts 와 PostSlide 컴포넌트에 props로 내려주었다. 하지만, 이 두개의 각 컴포넌트 내에서도 자식 컴포넌트로 쪼개고, 그 자식에게 받은 props를 전달해줬기 때문에 props drilling이 일어나므로 각 FeaturedPosts 와 PostSlide 컴포넌트도 어찌되었든 서버 컴포넌트이므로 async 컴포넌트로 만들어서 각각 api를 써서 정보를 가져오는 방식으로 바꾸었다. 다만 이렇게 될 경우 각 컴포넌트들이 비동기로 동작하는 컴포넌트가 되는데, 이 경우 Typescript 버전이 5.1.3 이상이고, @types/react도 18.2.8 이상이여야 _‘Promise<Element>’ is not a valid JSX element_ 라는 typescript 에러가 나타나지 않는다. (물론, **asyc/await 를 서버 컴포넌트인 layout, pages에서는 써도 에러가 나지 않지만, 다른 컴포넌트에선 에러가 나타난다**) 이 때 typescript 및 @types/react 를 업데이트 할 수 없는 상황이라면, import해온 컴포넌트 위에 `{/* @ts-expect-error Server Component */}` 를 명시해주면 에러가 해결된다.

4. FeaturedPosts 컴포넌트
화면 크기별로 보여지는 한줄의 포스트 개수가 달라져야 한다면, flex보다는 grid가 적합해보이며, grid가 적용된 컴포넌트로 분리했다.

5. SingleCarousel 컴포넌트
react-multi-carousel 사용시, 클릭과 같이 사용자와의 상호작용이 필요하기 때문에 'use client'를 명시해서 클라이언트 컴포넌트로 바꿔줘야 했다. 나는 전체 carousel 컴포넌트를 클라이언트 컴포넌트로 바꾸었으나, 최소 부분만 클라이언트 컴포넌트로 바꾸기 위해 Carousel을 사용하는 부분만 따로 SingleCarousel 컴포넌트로 빼서 그 부분만 클라이언트 컴포넌트로 바꿔주었다.

6. categories 가져오기
처음엔 categories들이 정해져있다고 생각하고, 이를 type union 으로 지정해버렸다. 이렇게 할 경우, 나중에 실제로 포스팅하고 카테고리를 추가해서 올리는 기능까지 추가한다면, 카테고리를 자유롭게 지정하지 못할 것이다. 따라서, 카테고리는 동적으로 가져오게끔 수정했다. 
이 때, new Set() 을 통해 중복된 카테고리를 제거했는데, 이 경우 typescript 설정 중 target (어떤 버전의 자바스크립트로 바꿔줄지 정하는 부분)이 기본 es5로 되어있어서 es6에 추가된  Set 자료구조에 대해 에러가 난다. 이 때 `tsconfig.json의 target 속성`을 `es6`로 바꿔주면 해결된다. 


### 간과하지 말아야할 사항
- use client 명시한 컴포넌트 내에서 import해와서 쓰는 자식 컴포넌트도 클라이언트 컴포넌트가 되므로 일일이 use client를 명시해줄 필요가 없다!
- 컴포넌트를 작은 단위로 나누자. 재사용성 뿐만 아니라 성능면에서도 중요하다. 상태나 props 업데이트가 빈번히 발생하는 컴포넌트일수록, 또는 그런 부모 컨테이너에 있는 UI 요소들을 작은 컴포넌트로 나누어 두면 불필요한 리렌더링을 방지할 수 있다





